### PR TITLE
Remove `_derived_visits` from derived_visits_metadata_builder.sql

### DIFF
--- a/_scripts/recover/job_scripts/derived_visits/derived_visits_metadata_builder.sql
+++ b/_scripts/recover/job_scripts/derived_visits/derived_visits_metadata_builder.sql
@@ -7,12 +7,12 @@ create table if not exists processing_metadata.derived_visits_meta as
 
 select
     meta_utils_id.value as dataset_ref,
-    colname|| '_derived_visits' || '_' || redcap_event_name || meta_utils_suffix.value as name,
+    colname|| '_' || redcap_event_name || meta_utils_suffix.value as name,
     colname || ' (biostats derived visits ' || redcap_event_name ||')' as display,
     (case when data_type = 'numeric' then 'continuous'
           else 'categorical'
         end) as concept_type,
-    '\' || meta_utils_id.value || '\' || meta_utils_name.value || '\biostats_derived_visits\' || colname|| '_derived_visits' || '_' || redcap_event_name || meta_utils_suffix.value|| '\' as concept_path,
+    '\' || meta_utils_id.value || '\' || meta_utils_name.value || '\biostats_derived_visits\' || colname|| '_' || redcap_event_name || meta_utils_suffix.value|| '\' as concept_path,
     json_build_object(
         --metadata key: description
             'description',


### PR DESCRIPTION
Remove `_derived_visits` from the name and concept path to match real column names created by get_derived_visits_subtables.sql. This ensures we have consistent naming between the data colname_redcap_event_name and the metadata colname_derived_visits_redcap_event_name.